### PR TITLE
chore: add version check and contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,25 @@
+# Contributing to CAD Sketcher
+
+Thank you for considering contributing to CAD Sketcher!
+
+## Getting Started
+- Ensure you are using a supported version of Blender and Python.
+- Install development dependencies as described in `README.md`.
+
+## Development Workflow
+1. Keep `blender_manifest.toml` and `__init__.py` version numbers in sync. Run:
+   ```bash
+   python scripts/check_versions.py
+   ```
+2. Run tests before submitting a pull request:
+   ```bash
+   bash run_tests.sh
+   ```
+3. Follow existing code style and prefer modular utilities over new global state.
+
+## Pull Requests
+- Describe your changes clearly.
+- Include tests or examples where possible.
+- Ensure your branch is rebased onto the latest `main`.
+
+We appreciate your contributions!

--- a/blender_manifest.toml
+++ b/blender_manifest.toml
@@ -1,7 +1,7 @@
 schema_version = "1.0.0"
 
 id = "CAD_Sketcher"
-version = "0.27.5"
+version = "0.27.6"
 name = "CAD Sketcher"
 tagline = "Parametric, constraint-based geometry sketcher"
 maintainer = "hlorus <dave19924@gmail.com>"

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,1 +1,6 @@
+#!/bin/bash
+
+# Ensure addon and manifest versions are in sync before running tests
+python3 scripts/check_versions.py || exit 1
+
 blender --addons CAD_Sketcher --python ./testing/__init__.py -- --log_level=INFO

--- a/scripts/check_versions.py
+++ b/scripts/check_versions.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+"""Check that version in blender_manifest.toml matches bl_info in __init__.py."""
+import re
+import sys
+from pathlib import Path
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # Python <3.11 fallback
+    import tomli as tomllib  # type: ignore
+
+root = Path(__file__).resolve().parents[1]
+manifest_path = root / "blender_manifest.toml"
+init_path = root / "__init__.py"
+
+# Read manifest version
+with manifest_path.open("rb") as f:
+    manifest_version = tomllib.load(f).get("version")
+
+# Read __init__.py for version tuple
+match = None
+with init_path.open("r", encoding="utf-8") as f:
+    content = f.read()
+    match = re.search(r"\"version\"\s*:\s*\(([^)]+)\)", content)
+
+if not match:
+    print("Could not find version in __init__.py")
+    sys.exit(1)
+
+init_version = ".".join(part.strip() for part in match.group(1).split(","))
+
+if manifest_version != init_version:
+    print(
+        f"Version mismatch: blender_manifest.toml has {manifest_version}, __init__.py has {init_version}"
+    )
+    sys.exit(1)
+
+print(f"Version check passed: {manifest_version}")


### PR DESCRIPTION
## Summary
- sync manifest version with `__init__`
- add contributor guidelines
- add script to verify version consistency and run it from tests

## Testing
- `python scripts/check_versions.py`
- `bash run_tests.sh` *(fails: blender: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8ee40bec083329b4a363870249888