### PR TITLE
Improve test scripts to check Blender availability

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ Thank you for considering contributing to CAD Sketcher!
    ```bash
    python scripts/check_versions.py
    ```
-2. Run tests before submitting a pull request:
+2. Run tests before submitting a pull request. These scripts require a local Blender installation available on your `PATH`:
    ```bash
    bash run_tests.sh
    ```

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+# Ensure Blender is installed before proceeding
+if ! command -v blender >/dev/null 2>&1; then
+  echo "Error: Blender executable not found. Install Blender to run tests." >&2
+  exit 1
+fi
+
 # Ensure addon and manifest versions are in sync before running tests
 python3 scripts/check_versions.py || exit 1
 

--- a/run_tests_interactive.sh
+++ b/run_tests_interactive.sh
@@ -1,1 +1,9 @@
+#!/bin/bash
+
+# Ensure Blender is installed before proceeding
+if ! command -v blender >/dev/null 2>&1; then
+  echo "Error: Blender executable not found. Install Blender to run interactive tests." >&2
+  exit 1
+fi
+
 blender --addons CAD_Sketcher --python ./testing/__init__.py -- --interactive --log_level=INFO


### PR DESCRIPTION
## Summary
- ensure `run_tests.sh` and `run_tests_interactive.sh` verify Blender is installed before running
- document Blender requirement for test scripts in `CONTRIBUTING.md`

## Testing
- `./run_tests.sh` *(fails: Blender executable not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae8937dbd083328850bdfc70311235